### PR TITLE
Modification to function pca.segments.2d (bug) AND function geneUsage (bug)

### DIFF
--- a/R/segments.R
+++ b/R/segments.R
@@ -114,7 +114,7 @@ geneUsage <- function (.data, .genes = HUMAN_TRBV_MITCR, .quant = c(NA, "read.co
       }
       
       if (length(gencols) > 0) {
-        x <- do.call(rbind, c(list(x), rep.int(0, length(gencols))))
+        x <- do.call(cbind, c(list(x), rep.int(0, length(gencols))))
         colnames(x)[(ncol(x) - length(gencols) + 1):ncol(x)] <- gencols
       }
 

--- a/R/segments.R
+++ b/R/segments.R
@@ -207,7 +207,7 @@ pca.segments.2D <- function(.data, .cast.freq.seg = T, ..., .text = T, .do.plot 
     pca.res <- data.frame(PC1 = pca.res$x[,1], PC2 = pca.res$x[,2], Subject = names(.data))
     p <- ggplot() + geom_point(aes(x = PC1, y = PC2, colour = Subject), size = 3, data = pca.res)
     if (.text) {
-      p <- geom_text(aes(x = PC1, y = PC2, label = Subject), data = pca.res, hjust=.5, vjust=-.3)
+      p <- p + geom_text(aes(x = PC1, y = PC2, label = Subject), data = pca.res, hjust=.5, vjust=-.3)
     }
     p <- p + theme_linedraw() + guides(size=F) + ggtitle("VJ-usage: Principal Components Analysis") + .colourblind.discrete(length(pca.res$Subject), T)
   } else {


### PR DESCRIPTION
In the function pca.segments.2D there seems to be an error when using .text = TRUE. It seems that p is overwritten by geom_text (p <- geom_text()) instead of modified (p <- p + geom_text()).

In the function geneUsage there seems to be a mistake in case of the joint gene distribution. For the part of gencols, the do.call function should contain cbind instead of rbind.
