### PR TITLE
Modification to function check.distribution (enhancement)

### DIFF
--- a/R/datatools.R
+++ b/R/datatools.R
@@ -331,7 +331,7 @@ apply.asymm <- function (.datalist, .fun, ..., .diag = NA, .verbose = T) {
 #' @return Numeric vector.
 check.distribution <- function (.data, .do.norm = NA, .laplace = 1, .na.val = 0, .warn.zero = F, .warn.sum = T) {
   if (sum(is.na(.data)) == length(.data)) {
-    cat("Error! Input vector is completely filled with NAs. Check your input data to avoid this. Returning vectors with zeros.\n")
+    warning("Error! Input vector is completely filled with NAs. Check your input data to avoid this. Returning vectors with zeros.\n")
     return(rep.int(0, length(.data)))
   }
   
@@ -347,13 +347,21 @@ check.distribution <- function (.data, .do.norm = NA, .laplace = 1, .na.val = 0,
   }
   
   if (.warn.zero && (0 %in% .data)) {
-    cat("Warning! There are", sum(which(.data == 0)), "zeros in the input vector. Function may produce incorrect results.\nTo fix this try to set .laplace = 1 or any other small number in the function's parameters\n")
+	  warningText <- paste("Warning! There are", sum(which(.data == 0)), "zeros in the input vector. Function may produce incorrect results.\n")
+	  if(.laplace != 1){
+		  warningText <- paste(warningText, "To fix this try to set .laplace = 1 or any other small number in the function's parameters\n")
+	  }else{
+		  warningText <- paste(warningText, "To fix this try to set .laplace to any other small number in the function's parameters\n")
+	  } 
+	  warning(warningText)
   }
   
   if (.warn.sum && sum(.data) != 1) {
-    cat("Warning! Sum of the input vector is NOT equal to 1. Function may produce incorrect results.\nTo fix this try to set .do.norm = TRUE in the function's parameters.\n")
+	  warningText <- "Warning! Sum of the input vector is NOT equal to 1. Function may produce incorrect results.\n"
+	  if(!isTRUE(.do.norm)) warningText <- paste(warningText, "To fix this try to set .do.norm = TRUE in the function's parameters.\n")
+	  warning(warningText)
     if (abs(sum(.data) - 1) < 1e-14) {
-      cat("Note: difference between the sum of the input vector and 1 is ", (sum(.data) - 1), ", which may be caused by internal R subroutines and may not affect the result at all.\n")
+      message("Note: difference between the sum of the input vector and 1 is ", (sum(.data) - 1), ", which may be caused by internal R subroutines and may not affect the result at all.\n")
     }
   }
   

--- a/R/segments.R
+++ b/R/segments.R
@@ -114,7 +114,7 @@ geneUsage <- function (.data, .genes = HUMAN_TRBV_MITCR, .quant = c(NA, "read.co
       }
       
       if (length(gencols) > 0) {
-        x <- do.call(rbind, c(list(x), rep.int(0, length(gencols))))
+        x <- do.call(cbind, c(list(x), rep.int(0, length(gencols))))
         colnames(x)[(ncol(x) - length(gencols) + 1):ncol(x)] <- gencols
       }
 

--- a/R/segments.R
+++ b/R/segments.R
@@ -207,7 +207,7 @@ pca.segments.2D <- function(.data, .cast.freq.seg = T, ..., .text = T, .do.plot 
     pca.res <- data.frame(PC1 = pca.res$x[,1], PC2 = pca.res$x[,2], Subject = names(.data))
     p <- ggplot() + geom_point(aes(x = PC1, y = PC2, colour = Subject), size = 3, data = pca.res)
     if (.text) {
-      p <- geom_text(aes(x = PC1, y = PC2, label = Subject), data = pca.res, hjust=.5, vjust=-.3)
+      p <- p + geom_text(aes(x = PC1, y = PC2, label = Subject), data = pca.res, hjust=.5, vjust=-.3)
     }
     p <- p + theme_linedraw() + guides(size=F) + ggtitle("VJ-usage: Principal Components Analysis") + .colourblind.discrete(length(pca.res$Subject), T)
   } else {


### PR DESCRIPTION
- For the warnings inside the function check.distribution, the function 'cat' is used. This results in printed text in the output. Is it possible to use warning or message instead?
- Currently the use of set .do.norm = TRUE is suggested when the sum(.data)!=1, even if you already has considered TRUE for this parameter. Maybe it is an idea to only suggest this, when NA or FALSE is considered for .do.norm?
