### PR TITLE
Morista index on duplicate-kept data doesn't work

### DIFF
--- a/R/repoverlap.R
+++ b/R/repoverlap.R
@@ -116,8 +116,11 @@ repOverlap <- function (.data,
         if (.verbose) { add.pb(pb) }
       }
       if (.verbose) { close(pb) }
+    } else {
+      for (i in 1:length(.data)) {
+        .data[[i]] <- data.frame(Sequence = new.data[[i]], Count = new.reads[[i]], stringsAsFactors = F))
+      }
     }
-    
     .pair.fun(.data,
               function (x, y) { .fun(x, y) },
               .verbose)


### PR DESCRIPTION
If .do.unique is FALSE, then the .data variable doesn't get updated to be the two-column data.frame that appears to be required by the 'morista' function